### PR TITLE
Enable changelog reset on repos

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -109,3 +109,19 @@ resource "github_repository_webhook" "release_creator" {
 
   events = ["pull_request"]
 }
+
+resource "github_repository_webhook" "changelog_reset" {
+  repository = github_repository.repository.name
+  count      = var.changelog_reset_config.enabled ? 1 : 0
+
+  configuration {
+    url          = var.changelog_reset_config.url
+    content_type = "form"
+    insecure_ssl = false
+    secret       = var.changelog_reset_config.secret
+  }
+
+  active = true
+
+  events = ["release"]
+}

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -28,3 +28,9 @@ variable "release_creator_config" {
     enabled = false
   }
 }
+
+variable "changelog_reset_config" {
+  default = {
+    enabled = false
+  }
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -5,6 +5,7 @@ module "changelog_reset" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   description                = "Resets a changelog back to the ## Unreleased heading from a github release webhook event"
   providers = {
     github              = github
@@ -20,6 +21,7 @@ module "labelvalidator" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot
@@ -34,6 +36,7 @@ module "json_version_bumper" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot
@@ -49,6 +52,7 @@ module "release_creator" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot
@@ -64,6 +68,7 @@ module "github-label-manager" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot
@@ -78,6 +83,7 @@ module "github-cookstyle-runner" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot
@@ -93,6 +99,7 @@ module "github-file-manager" {
   label_validator_config     = local.label_validator_config
   json_version_bumper_config = local.json_version_bumper_config
   release_creator_config     = local.release_creator_config
+  changelog_reset_config     = local.changelog_reset_config
   providers = {
     github              = github
     github.collaborator = github.xorimabot

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,13 @@ locals {
     enabled = true
   }
 }
+
+variable "changelog_reset_url" {}
+
+locals {
+  changelog_reset_config = {
+    url     = var.changelog_reset_url
+    secret  = var.webhook_secret_key
+    enabled = true
+  }
+}


### PR DESCRIPTION
## Description

Enables the changelog reset webhook on repos

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
